### PR TITLE
Add option to use column layout for gallery

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,10 +9,11 @@ import { CinemaHall } from './components/CinemaHall';
 
 function App() {
   const [isFooterVisible, setShowFooter] = useState(false);
+  const [direction, setDirection] = useState('row');
   const [theme, setTheme] = useState(THEME_LIGHT);
 
   useEffect(() => {
-    setFooterStatus(setShowFooter);
+    setViewOptions(setShowFooter, setDirection);
   }, []);
 
   const toggleTheme = () => {
@@ -22,7 +23,7 @@ function App() {
   return (
     <div className="App">
       <main className={ `main ${theme}` }>
-        <Gallery theme={theme} />
+        <Gallery theme={theme} direction={direction}/>
         <CinemaHall theme={theme} />
       </main>
 
@@ -59,11 +60,13 @@ export default App;
 /**
  * @returns {Promise<void>}
  */
-async function setFooterStatus(set) {
+async function setViewOptions(setFooterVisible, setDirection) {
   try {
-    const { isFooterVisible } = await fetch('/api/view');
+    const { isFooterVisible, isColumnLayout } = await fetch('/api/view');
+    const direction = isColumnLayout ? 'column' : 'row';
 
-    typeof isFooterVisible === 'boolean' && set(isFooterVisible);
+    typeof isFooterVisible === 'boolean' && setFooterVisible(isFooterVisible);
+    typeof isColumnLayout === 'boolean' && setDirection(direction);
   } catch (error) {
     return console.error('fetchImages', error);
   }

--- a/client/src/components/Gallery.js
+++ b/client/src/components/Gallery.js
@@ -12,7 +12,7 @@ import './Gallery.css';
 export const THEME_LIGHT = 'light';
 export const THEME_DARK = 'dark';
 
-export function Gallery({ theme }) {
+export function Gallery({ theme, direction }) {
   const [photos, setPhotos] = useState([]);
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -38,7 +38,7 @@ export function Gallery({ theme }) {
 
     {photos.length ? <PhotoWall
       photos={photos}
-      direction={'row'}
+      direction={direction}
       onClick={(_, { index }) => toggleModal(index)}
     /> : null}
   </div>);

--- a/server/app.js
+++ b/server/app.js
@@ -48,6 +48,7 @@ program
   .usage('-f <folder>')
   .option('-f, --folder <folder>', 'photos folder to serve')
   .option('-d, --directory <directory>', 'photos folder to serve')
+  .option('-c, --column', 'use column layout')
   .option('-p, --port <port>', 'server port')
   .option('-t, --token <token>', 'secret token to prevent eavesdropping')
   .option('--no-footer', 'hide the footer bar')
@@ -58,8 +59,8 @@ program.parse(process.argv);
 const {
   folder,
   directory,
-  footer:
-  isFooterVisible,
+  column: isColumnLayout,
+  footer: isFooterVisible,
   token: tokenFromCli,
   port: portFromCli,
 } = program;
@@ -172,6 +173,7 @@ function normalizePath(path) {
 
 function sendViewInfo(ctx) {
   ctx.body = {
+    isColumnLayout,
     isFooterVisible,
   };
 }


### PR DESCRIPTION
While fixing the portrait image aspect ratio issue on #1, I noticed React Photo Gallery also supports vertical tiling layout. I thought it looks pretty cool, so I've added a new option `-c --column  Use column layout`. Without it everything should work as before.